### PR TITLE
Feat/updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ data/
 .pentaho/
 .Xauthority
 .ipynb_checkpoints/
-pdi-ce-7.1.0.0-12.zip
+pdi-ce-*.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@ MAINTAINER Andre Pereira andrespp@gmail.com
 MAINTAINER Thiago Mota tgmspawn@gmail.com
 
 # Set Environment Variables
-ENV PDI_VERSION=7.1 PDI_BUILD=7.1.0.0-12 \
+ENV PDI_VERSION=9.1 PDI_BUILD=9.1.0.0-324 \
 	PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/data-integration \
 	KETTLE_HOME=/data-integration
 
 # Download PDI
-RUN wget --progress=dot:giga http://downloads.sourceforge.net/project/pentaho/Data%20Integration/${PDI_VERSION}/pdi-ce-${PDI_BUILD}.zip \
+RUN wget --progress=dot:giga http://downloads.sourceforge.net/project/pentaho/Pentaho%20${PDI_VERSION}/client-tools/pdi-ce-${PDI_BUILD}.zip \
 	&& unzip -q *.zip \
 	&& rm -f *.zip \
 	&& mkdir /jobs

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN wget --progress=dot:giga http://downloads.sourceforge.net/project/pentaho/Da
 	&& rm -f *.zip \
 	&& mkdir /jobs
 
-# Aditional Drivers
+# Additional Drivers
 WORKDIR $KETTLE_HOME
 
 RUN wget https://downloads.sourceforge.net/project/jtds/jtds/1.3.1/jtds-1.3.1-dist.zip \
@@ -23,7 +23,7 @@ RUN wget https://downloads.sourceforge.net/project/jtds/jtds/1.3.1/jtds-1.3.1-di
 	&& unzip Jaybird-3.0.4-JDK_1.8.zip -d lib \
 	&& rm -rf lib/docs/ Jaybird-3.0.4-JDK_1.8.zip
 
-# Adictional Setup
+# Additional Setup
 COPY ./setup.sh /
 RUN chmod +x /setup.sh \
 	&& . /setup.sh

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ endif
 
 IMAGE?=pdi
 APP=spoon
+DOCKERFILE?=Dockerfile
 
 .PHONY: help
 help:
@@ -14,7 +15,7 @@ help:
 	@echo "Targets:"
 	@echo "  help\t\tPrint this help"
 	@echo "  test\t\tLookup for docker binary"
-	@echo "  setup\t\tBuild docker images"
+	@echo "  setup [DOCKERFILE]\tBuild docker image defined in '\$$DOCKERFILE' (Dockerfile by default)"
 	@echo "  run [app]\tRun app defined in '\$$APP' (spoon by default)"
 	@echo ""
 	@echo "Example: make run APP=spoon"
@@ -25,8 +26,8 @@ test:
 	@which xauth
 
 .PHONY: setup
-setup: Dockerfile
-	docker image build -t $(IMAGE) .
+setup: $(DOCKERFILE)
+	docker image build -t $(IMAGE) -f $(DOCKERFILE) .
 
 .PHONY: run
 run:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-IMAGE=pdi
+# pull in any overrides to IMAGE from the .env file
+ifneq (,$(wildcard ./.env))
+    include .env
+    export
+endif
+
+IMAGE?=pdi
 APP=spoon
 
 .PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help:
 	@echo
 	@echo "Targets:"
 	@echo "  help\t\tPrint this help"
-	@echo "  test\t\tLookup for docker and docker-compose binaries"
+	@echo "  test\t\tLookup for docker binary"
 	@echo "  setup\t\tBuild docker images"
 	@echo "  run [app]\tRun app defined in '\$$APP' (spoon by default)"
 	@echo ""
@@ -22,7 +22,6 @@ help:
 .PHONY: test
 test:
 	@which docker
-	@which docker-compose
 	@which xauth
 
 .PHONY: setup

--- a/README.md
+++ b/README.md
@@ -82,11 +82,10 @@ This image uses several environment variables in order to control its behavior, 
 
 | Environment variable | Default value | Note |
 | -------------------- | ------------- | -----|
-| PDI\_VERSION | 7.1 | |
+| PDI\_VERSION | 9.1 | |
 | |  | |
 
 # Issues
 
 If you have any problems with or questions about this image, please contact me
 through a [GitHub issue](https://github.com/tgmti/docker-pdi/issues).
-

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Usage:	/entrypoint.sh COMMAND
 Pentaho Data Integration (PDI)
 
 Options:
+  encr password		Obfuscate a password
   runj filename		Run job file
   runt filename		Run transformation file
   spoon			    Run spoon (GUI)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Docker Pentaho Data Integration
 
 DockerFile for [Pentaho Data Integration](https://sourceforge.net/projects/pentaho/) (a.k.a kettel / PDI)
 
-This image is intendend to allow execution os PDI transformations and jobs throught command line and run PDI's UI (`Spoon`). PDI server (`Carter`) is available on this image.
+This image is intended to allow execution of PDI transformations and jobs through command line and run PDI's UI (`Spoon`). PDI server (`Carte`) is available on this image.
 
 # Quick start
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,15 @@ custom_properties() {
 	fi
 }
 
+encr() {
+	custom_properties
+	# set the path to java so the encr.sh script will work
+	. ./set-pentaho-env.sh
+	setPentahoEnv
+	export PATH=$PATH:$_PENTAHO_JAVA_HOME/bin
+	./encr.sh -kettle $1
+}
+
 run_pan() {
 	custom_properties
 	echo ./pan.sh -file $@
@@ -42,6 +51,7 @@ Usage:	$0 COMMAND
 Pentaho Data Integration (PDI)
 
 Options:
+  encr password		Obfuscate a password
   runj filename		Run job file
   runt filename		Run transformation file
   spoon			Run spoon (GUI)
@@ -52,6 +62,10 @@ Options:
 case "$1" in
     help)
         print_usage
+        ;;
+    encr)
+	shift 1
+        encr "$@"
         ;;
     runt)
 	shift 1

--- a/setup.sh
+++ b/setup.sh
@@ -5,4 +5,4 @@ echo deb 'http://cz.archive.ubuntu.com/ubuntu bionic main universe' >> /etc/apt/
 
 ## Add repository PUB_KEY
 KEYS=$(apt update 2>&1 1>/dev/null | sed -ne 's/.*NO_PUBKEY //p')
-echo $KEYS | while read key; do apt-key adv --keyserver hkp://pool.sks-keyservers.net:80 --recv-keys "$key"; done
+echo $KEYS | while read key; do apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "$key"; done

--- a/spoon
+++ b/spoon
@@ -1,7 +1,15 @@
 #!/bin/bash
 #set -x
 
-IMAGE=tgmti/pdi
+# pull in any overrides to IMAGE from the .env file
+if [ -f .env ]
+then
+  export $(sed 's/#.*//g' .env)
+fi
+
+# Use image name including dockerhub user unless
+# overwritten in .env file with a custom local image name
+IMAGE=${IMAGE:="tgmti/pdi"}
 CONTAINER_NAME=spoon
 
 is_running(){


### PR DESCRIPTION
Bumping the version up to the latest version (9.1)

Adding the ability to set the image name via .env file so that the code doesn't need to be overwritten in each fork.

Fixing/adding the encr.sh script to the entrypoint so it can be used from the outside to encrypt passwords and set them in the kettle.properties file. 